### PR TITLE
Fix ReferenceError thrown by service command

### DIFF
--- a/commands/service.js
+++ b/commands/service.js
@@ -17,16 +17,16 @@ module.exports = {
 		const query = interaction.options.getString('query');
 		const response = await fetch(`https://api.tosdr.org/search/v4/?query=${query}`, {method: 'GET'})
 			.then(res => res.json())
-			.catch(err => log.error('error:' + err));
+			.catch(err => log.error('fetch error:' + err));
 		const services = response.parameters.services;
 		if (services.length == 0) return interaction.reply("No results!");
-		
+
 		const pagination = new Pagination(interaction);
 		let embeds = [], index = 1;
-		services.forEach(service => {
-			embeds.push(buildServiceEmbed(service));
+		for(const service of services) {
+			embeds.push(buildServiceEmbed(service, embedColor, index, services.length));
 			index++;
-		});
+		}
 
 		pagination.setEmbeds(embeds);
 		pagination.render(); // Render and send embed(s)

--- a/util/functions.js
+++ b/util/functions.js
@@ -24,10 +24,10 @@ function getStatusString(status_string) {
 	};
 }
 
-function buildServiceEmbed(service, embed_color, index) {
+function buildServiceEmbed(service, embed_color, index, serviceCount) {
 	return new EmbedBuilder()
 		.setColor(embed_color)
-		.setFooter({text:`Result ${index}/${services.length}`})
+		.setFooter({text:`Result ${index}/${serviceCount}`})
 		.setImage(service.links.crisp.badge.png)
 		.setThumbnail(`https://s3.tosdr.org/logos/${service.id}.png`)
 		.setTitle(service.name)


### PR DESCRIPTION
- Move total service results to argument.
- Add missing `buildServiceEmbed()` arguments
- Move iteration from deprecated `forEach()` to `for (const x of y)`.
- Make fetch error clearer.